### PR TITLE
Core: Extend Pixel experience Blacklist For Google Photos

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -711,6 +711,20 @@ public class ApplicationPackageManager extends PackageManager {
 
     @Override
     public boolean hasSystemFeature(String name, int version) {
+        String packageName = ActivityThread.currentPackageName();
+        if (packageName != null &&
+                packageName.contains("com.google.android.apps.photos") &&
+                name.contains("PIXEL_2021_EXPERIENCE") ||
+                name.contains("PIXEL_2021_MIDYEAR_EXPERIENCE") ||
+                name.contains("PIXEL_2020_EXPERIENCE") ||
+                name.contains("PIXEL_2020_MIDYEAR_EXPERIENCE") ||
+                name.contains("PIXEL_2019_EXPERIENCE") ||
+                name.contains("PIXEL_2019_PRELOAD") ||
+                name.contains("PIXEL_2019_MIDYEAR_EXPERIENCE") ||
+                name.contains("PIXEL_2018_PRELOAD") ||
+                name.contains("PIXEL_2017_PRELOAD")) {
+            return false;
+        }
         return mHasSystemFeatureCache.query(new HasSystemFeatureQuery(name, version));
     }
 


### PR DESCRIPTION
Turns out having these breaks Original quality backups.
Since these indicate that the device is pixel 4 with in the turn breaks device spoofing as OG pixel

Change-Id: I336facff7b55552f094997ade337656461a0ea1d